### PR TITLE
Add admin permissions for namespace owner to ArgoCD

### DIFF
--- a/helm/cicd/templates/argocd.yaml
+++ b/helm/cicd/templates/argocd.yaml
@@ -7,6 +7,12 @@ metadata:
 spec:
   dex:
     openShiftOAuth: true
+  rbac:
+    policy: |
+      g, system:cluster-admins, role:admin
+      g, cluster-admins, role:admin
+      g, {{ .Values.namespacePermissions.user }}, role:admin      
+    scopes: '[name,groups]'
   server:
     route:
       enabled: true


### PR DESCRIPTION
Found a way to have the userX be an admin in their ArgoCD